### PR TITLE
returns param value

### DIFF
--- a/lib/sinatra/param.rb
+++ b/lib/sinatra/param.rb
@@ -21,6 +21,7 @@ module Sinatra
         params[name] = (options[:default].call if options[:default].respond_to?(:call)) || options[:default] if params[name].nil? and options[:default]
         params[name] = options[:transform].to_proc.call(params[name]) if params[name] and options[:transform]
         validate!(params[name], options)
+        params[name]
       rescue InvalidParameterError => exception
         if options[:raise] or (settings.raise_sinatra_param_exceptions rescue false)
           exception.param, exception.options = name, options


### PR DESCRIPTION
Porting https://github.com/sdalu PR.

To  ease parameter handling, also returns the coerced/transformed value, making possible to write:
```ruby
query = param :q, String
```