### PR TITLE
Add all_or_none_of validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
+language: ruby
+rvm:
+    - 2.3
 before_install:
-  - gem install bundler
+    - gem install bundler

--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ param :a, Hash do
 end
 ```
 
+## All Or None Of
+
+Using `all_or_none_of`, a router can specify that _all_ or _none_ of a set of parameters are required, and fail if _some_ are provided:
+
+```ruby
+param :x, String
+param :y, String
+
+all_or_none_of :x,:y
+```
+
 ### Exceptions
 
 By default, when a parameter precondition fails, `Sinatra::Param` will `halt 400` with an error message:

--- a/spec/dummy/app.rb
+++ b/spec/dummy/app.rb
@@ -297,10 +297,6 @@ class App < Sinatra::Base
     param :parent, String do
       param :child, String
     end
-
-    {
-      message: 'OK'
-    }.to_json
   end
 
   get '/one_of/nested' do
@@ -325,6 +321,18 @@ class App < Sinatra::Base
 
       any_of :a, :b, :c
     end
+
+    {
+      message: 'OK'
+    }.to_json
+  end
+
+  get '/all_or_none_of' do
+    param :a, String
+    param :b, String
+    param :c, String
+
+    all_or_none_of :a, :b, :c
 
     {
       message: 'OK'

--- a/spec/parameter_conjunctivity_spec.rb
+++ b/spec/parameter_conjunctivity_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'Parameter Sets' do
+  describe 'all_or_none_of' do
+    it 'returns 400 on requests that have some but not all required parameters' do
+      params = [
+        {a: 1},
+        {b: 2, c: 3},
+        {a: 1, c: 3},
+      ]
+
+      params.each do |param|
+        get('/all_or_none_of', param) do |response|
+          expect(response.status).to eql 400
+          expect(JSON.parse(response.body)['message']).to match(/^Invalid parameters/)
+        end
+      end
+    end
+
+    it 'returns successfully for requests that have all parameters' do
+      param = {a: 1, b: 2, c: 3}
+
+      response = get("/all_or_none_of", param)
+      expect(response.status).to eql 200
+      expect(JSON.parse(response.body)['message']).to match(/OK/)
+    end
+
+    it 'returns successfully for requests that have none of the parameters' do
+      response = get("/all_or_none_of")
+      expect(response.status).to eql 200
+      expect(JSON.parse(response.body)['message']).to match(/OK/)
+    end
+  end
+end


### PR DESCRIPTION
Porting https://github.com/petedmarsh PR.

This validates that *all* or *none* of a set of parameters have been
specified, if only a (strict) subset has been given then an error
will be raised/returned, e.g.

    get '/example' do
      param :x, String
      param :y, String

      all_or_none_of :x, :y
    end

    GET /example?x=abc #invalid
    GET /example?y=def #invalid
    GET /example?x=abc&y=def #valid