### PR TITLE
sinatra-2: Updates for sinatra 2 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+/build/
 
 # Documentation
 /.yardoc/
@@ -27,3 +28,6 @@ Gemfile.lock
 
 # RVM
 .rvmrc
+
+# IDEA IDE
+/.idea/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# sinatra-param
+# sinatra-param2
 _Parameter Validation & Type Coercion for Sinatra_
+
+**`sinatra-param2` is a fork of [`sinatra-param`](https://github.com/mattt/sinatra-param) that works with Sinatra 2 and has many nice additions.**
 
 REST conventions take the guesswork out of designing and consuming web APIs. Simply `GET`, `POST`, `PATCH`, or `DELETE` resource endpoints, and you get what you'd expect.
 
@@ -7,22 +9,22 @@ However, when it comes to figuring out what parameters are expected... well, all
 
 This Sinatra extension takes a first step to solving this problem on the developer side
 
-**`sinatra-param` allows you to declare, validate, and transform endpoint parameters as you would in frameworks like [ActiveModel](http://rubydoc.info/gems/activemodel/3.2.3/frames) or [DataMapper](http://datamapper.org/).**
+**`sinatra-param2` allows you to declare, validate, and transform endpoint parameters as you would in frameworks like [ActiveModel](http://rubydoc.info/gems/activemodel/3.2.3/frames) or [DataMapper](http://datamapper.org/).**
 
-> Use `sinatra-param` in combination with [`Rack::PostBodyContentTypeParser` and `Rack::NestedParams`](https://github.com/rack/rack-contrib) to automatically parameterize JSON `POST` bodies and nested parameters.
+> Use `sinatra-param2` in combination with [`Rack::PostBodyContentTypeParser` and `Rack::NestedParams`](https://github.com/rack/rack-contrib) to automatically parameterize JSON `POST` bodies and nested parameters.
 
 ## Install
 
-You can install `sinatra-param` from the command line with the following:
+You can install `sinatra-param2` from the command line with the following:
 
 ```bash
-$ gem install sinatra-param
+$ gem install sinatra-param2
 ```
 
-Alternatively, you can specify `sinatra-param` as a dependency in your `Gemfile` and run `$ bundle install`:
+Alternatively, you can specify `sinatra-param2` as a dependency in your `Gemfile` and run `$ bundle install`:
 
 ```ruby
-gem "sinatra-param", require: "sinatra/param"
+gem "sinatra-param2", require: "sinatra/param"
 ```
 
 ## Example
@@ -179,8 +181,8 @@ one_of :q, :categories, raise: true
 
 ## Contact
 
-Mattt Thompson ([@mattt](http://twitter.com/mattt))
+Adrian Bravo ([@adrianbravon](http://twitter.com/adrianbravon))
 
 ## License
 
-sinatra-param is released under an MIT license. See LICENSE for more information.
+sinatra-param2 is released under an MIT license. See LICENSE for more information.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # sinatra-param2
+[![Build Status](https://travis-ci.org/adrianbn/sinatra-param.png)](https://travis-ci.org/adrianbn/sinatra-param)
+
 _Parameter Validation & Type Coercion for Sinatra_
 
 **`sinatra-param2` is a fork of [`sinatra-param`](https://github.com/mattt/sinatra-param) that works with Sinatra 2 and has many nice additions.**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # sinatra-param2
-[![Build Status](https://travis-ci.org/adrianbn/sinatra-param.png)](https://travis-ci.org/adrianbn/sinatra-param)
+[![Build Status](https://travis-ci.org/adrianbn/sinatra-param.svg?branch=master)](https://travis-ci.org/adrianbn/sinatra-param)
 
 _Parameter Validation & Type Coercion for Sinatra_
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,12 @@
 require "bundler"
 Bundler.setup
 
-gemspec = eval(File.read("sinatra-param.gemspec"))
+gemspec = eval(File.read("sinatra-param2.gemspec"))
 
 task :build => "#{gemspec.full_name}.gem"
 
-file "#{gemspec.full_name}.gem" => gemspec.files + ["sinatra-param.gemspec"] do
-  system "gem build sinatra-param.gemspec"
+file "#{gemspec.full_name}.gem" => gemspec.files + ["sinatra-param2.gemspec"] do
+  system "gem build sinatra-param2.gemspec"
 end
 
 begin

--- a/lib/sinatra/param/version.rb
+++ b/lib/sinatra/param/version.rb
@@ -1,5 +1,5 @@
 module Sinatra
   module Param
-    VERSION = '1.4.0'
+    VERSION = '1.0.0'
   end
 end

--- a/sinatra-param2.gemspec
+++ b/sinatra-param2.gemspec
@@ -2,22 +2,23 @@
 require File.expand_path('../lib/sinatra/param/version', __FILE__)
 
 Gem::Specification.new do |s|
-  s.name        = "sinatra-param"
+  s.name        = "sinatra-param2"
   s.license     = "MIT"
-  s.authors     = ["Mattt Thompson"]
-  s.email       = "m@mattt.me"
-  s.homepage    = "https://github.com/mattt/sinatra-param"
+  s.authors     = ["Mattt Thompson", "Adrian Bravo"]
+  s.email       = "adrianbn@gmail.com"
+  s.homepage    = "https://github.com/adrianbn/sinatra-param2"
   s.version     = Sinatra::Param::VERSION
   s.platform    = Gem::Platform::RUBY
   s.summary     = "Parameter Validation & Type Coercion for Sinatra."
-  s.description = "sinatra-param allows you to declare, validate, and transform endpoint parameters as you would in frameworks like ActiveModel or DataMapper."
+  s.description = "sinatra-param2 allows you to declare, validate, and transform endpoint parameters as you would in frameworks like ActiveModel or DataMapper."
 
-  s.add_dependency "sinatra", "~> 1.3"
+  s.add_dependency "sinatra", "~> 2.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rack-test"
   s.add_development_dependency "simplecov"
+  s.add_development_dependency "simplecov-cobertura"
 
   s.files         = Dir["./**/*"].reject { |file| file =~ /\.\/(bin|log|pkg|script|spec|test|vendor)/ }
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/parameter_raise_spec.rb
+++ b/spec/parameter_raise_spec.rb
@@ -5,7 +5,7 @@ describe 'Exception' do
     it 'should raise error when option is specified' do
       expect {
         get('/raise/validation/required')
-      }.to raise_error
+      }.to raise_error(Sinatra::Param::InvalidParameterError)
     end
   end
 
@@ -13,13 +13,13 @@ describe 'Exception' do
     params = {a: 1, b: 2, c: 3}
     expect {
       get('/raise/one_of/3', params)
-    }.to raise_error
+    }.to raise_error(Sinatra::Param::InvalidParameterError)
   end
 
   it 'should raise error when no parameters are specified' do
     params = {}
     expect {
       get('/raise/any_of', params)
-    }.to raise_error
+    }.to raise_error(Sinatra::Param::InvalidParameterError)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,19 @@
 unless ENV['CI']
   require 'simplecov'
-  SimpleCov.start do
-    add_filter 'spec'
-    add_filter '.bundle'
-  end
+	require 'simplecov-cobertura'
+	SimpleCov.start do
+		add_filter '/spec/'
+		add_filter '.bundle'
+		minimum_coverage(70)
+		coverage_dir "#{Dir.pwd}/build/reports"
+		SimpleCov.formatters = [
+			SimpleCov::Formatter::HTMLFormatter,
+			SimpleCov::Formatter::CoberturaFormatter
+		]
+	end
 end
+
+
 
 require 'sinatra/param'
 


### PR DESCRIPTION
  Updated required dependencies to run sinatra-param2 against Sinatra 2.
  It seems that it works out of the box with the updated dependencies.
  Updated contact and naming information, both in README and gemspec.
  Reset version to 1.0.0 to signify the start of sinatra-param2 and the
  break from sinatra-param.